### PR TITLE
Updates and Cleanup... no hedge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@
   </p>
 </div>
 
+This fork has a few improvements over the original drift [keeper-bots-v2](https://github.com/drift-labs/keeper-bots-v2) relating to pricing, monitoring, and other operations. The improvements are detailed below. 
+
+### Pricing and Hedging
+- Rather than filling every jit auction with the auction start price use the mid price direct from the oracle. Often this is a significant difference even though the auction start price is also the oracle price. 
+- Checking if the oracle is active and not erroring (would lead to auctions being filled at bad prices)
+- If funding rate for a position is greater than the # orders filled * the maker rebate (1.2bps) set to close
+- There is a chance that an order from the dlob is heard out of order and unable to be processed initially, added in checks to see if the failed submission of an order is still in the dlob and will submit to fill again 
+- While running this bot you do not want to take on to much delta exposure. When `MAX_POSITION_EXPOSURE` (default 10% collateral) is reached all positions will be set to reduce only mode. Capping the bots delta exposure is important but also limits the bot to filling jit auctions with only ~10% of it's collateral before it only participates in orders that reduce its exposure. Now when `MAX_POSITION_EXPOSURE` is reached, the delta will be hedged on [01](https://01.exchange) allowing the bot to continue filling **all** orders.
+
+### Monitoring and Logging
+- Dashboards for monitoring orders and pnl, along with logs, and hardware statistics
+- Logging with Loki
+
+### Custody
+- Implementation of Vault as a key-value store with the experimental additions of a plugin 
+
 # Setting up
 ## Setup Environment
 ```shell

--- a/secrets-engine/.gitignore
+++ b/secrets-engine/.gitignore
@@ -2,4 +2,5 @@ DS_Store
 .idea
 .vscode
 
-/vault
+./vault
+./vault/plugins

--- a/secrets-engine/README.md
+++ b/secrets-engine/README.md
@@ -1,5 +1,5 @@
 # Securely Storing Private Keys for Bot Operators 
-## **Expirmental***
+## **Experimental***
 ### Overview
 Right now most bot operaters use a `.env` file to store their private key in plain text. Compromising this key would lead to full control and access of the account. If the bot requires collateral to operate this is even more of a concern. 
 
@@ -13,7 +13,7 @@ The easiest way to integrate vault is through pushing your private key as a key-
 
 Note, needing to read the private key from a key-value pair in your program is far better than storing in an `.env` (for security, flexability, and an audit trail) but still leaves the private key in memory which can easily be dumped and read!
 
-The best and most secure usage is to have a module within hashicorp that listens for a raw unsigned transaction and signs it within the vault (also note: very expiremental feature). [github.com/saberistic/solana-secrets-engine](https://github.com/saberistic/solana-secrets-engine) starts on this work, and I plan on continuing and improving it in the future.
+The best and most secure usage is to have a module within hashicorp that listens for a raw unsigned transaction and signs it within the vault (also note: very experimental feature). [github.com/saberistic/solana-secrets-engine](https://github.com/saberistic/solana-secrets-engine) starts on this work, and I plan on continuing and improving it in the future.
 
 ### Key Value Usage 
 ```

--- a/secrets-engine/backend.go
+++ b/secrets-engine/backend.go
@@ -94,7 +94,6 @@ func (b *backend) handleExistenceCheck(ctx context.Context, req *logical.Request
 }
 
 func (b *backend) handleRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	b.Backend.Logger().Info("REEEEAAAAD")
 	if req.ClientToken == "" {
 		return nil, fmt.Errorf("client token empty")
 	}

--- a/src/bots/filler.ts
+++ b/src/bots/filler.ts
@@ -685,7 +685,7 @@ export class FillerBot implements Bot {
 					}
 					this.dlob = new DLOB(
 						this.clearingHouse.getPerpMarketAccounts(),
-						this.clearingHouse.getSpotMarketAccounts(), // TODO: new sdk - remove this
+						this.clearingHouse.getSpotMarketAccounts(),
 						this.clearingHouse.getStateAccount(),
 						this.userMap,
 						true

--- a/src/bots/jitMaker.ts
+++ b/src/bots/jitMaker.ts
@@ -264,7 +264,6 @@ export class JitMakerBot implements Bot {
 		return this.dlob;
 	}
 
-	// TODO: understand this function more, why is a random choice being made?
 	/**
 	 * This function creates a distribution of the values in array based on the
 	 * weights array. The returned array should be used in randomIndex to make
@@ -325,8 +324,6 @@ export class JitMakerBot implements Bot {
 	 * Delta exposure can be hedged on an additional exchange or if the
 	 * exposure if + the bot can hedge via the spot market.
 	 *
-	 * // TODO: update the spot market and add it in to hedge the delta positions
-	 *
 	 * @returns {Promise<void>}
 	 */
 	private async updateAgentState(): Promise<void> {
@@ -378,7 +375,7 @@ export class JitMakerBot implements Bot {
 			}
 
 			// check if total position is greater than MAX_POSITION_EXPOSURE
-			// TODO: keep this, but expand it out to first logging delta exposure and second hedging it
+			// TODO: change MAX_POSITION_EXPOSURE to continue trading if the exposure can be hedged on another exchange
 			if (canUpdateStateBasedOnPosition) {
 				// check if need to enter a closing state
 				const accountCollateral = convertToNumber(
@@ -417,8 +414,6 @@ export class JitMakerBot implements Bot {
 				}
 			}
 		}
-		// given deltas on each market iterate and use spot markets to hedge
-		// TODO: hedge
 	}
 
 	/**
@@ -477,7 +472,6 @@ export class JitMakerBot implements Bot {
 		orderPrice: BN
 	): BN {
 		// convert the order base amount available to a number with the correct precision
-		// TODO: what is this precision?
 		const priceNumber = convertToNumber(orderPrice, PRICE_PRECISION);
 
 		// determine the worst case scenario for the base amount to fill
@@ -488,7 +482,6 @@ export class JitMakerBot implements Bot {
 			.mul(QUOTE_PRECISION);
 
 		// defining the minimum order quote
-		// TODO: this should be configurable
 		const minOrderQuote = 20;
 		let orderQuote = minOrderQuote;
 		// max quote is defined as the worst order possible
@@ -501,7 +494,6 @@ export class JitMakerBot implements Bot {
 
 		// if max if greater than the minimum quote that would be offered
 		// define the quote as a random number between the min and max
-		// TODO: CHANGE THIS!
 		if (maxOrderQuote >= minOrderQuote) {
 			orderQuote = this.randomIntFromInterval(minOrderQuote, maxOrderQuote);
 		}
@@ -536,12 +528,11 @@ export class JitMakerBot implements Bot {
 			node: node,
 		});
 
-		// TODO: add to metrics
 		// record the order being filled into the prometheus metrics
-		// this.metrics?.recordFilledOrder(
-		// 	this.clearingHouse.provider.wallet.publicKey,
-		// 	this.name
-		// );
+		this.metrics?.recordFilledOrder(
+			this.clearingHouse.provider.wallet.publicKey,
+			this.name
+		);
 
 		logger.info(
 			`Executed spot order for market ${node.order.marketIndex} ${baseAssetAmount} `
@@ -784,7 +775,6 @@ export class JitMakerBot implements Bot {
 					this.name
 				);
 
-				// TODO: log information specific to certain errors and maybe take action on it
 				if (errorCode == 6094) {
 					logger.error(
 						`Error Post-only order can immediately fill the auction (account: ${nodeToFill.node.userAccount.toString()} - ${nodeToFill.node.order.orderId.toString()})`
@@ -808,8 +798,6 @@ export class JitMakerBot implements Bot {
 		action: Action
 	): Promise<TransactionSignature> {
 		// const currentState = this.agentState.stateType.get(action.marketIndex);
-
-		// TODO: might need to add in some check for user account and spot
 
 		const takerUserAccount = (
 			await this.userMap.mustGet(action.node.userAccount.toString())

--- a/src/bots/spotFiller.ts
+++ b/src/bots/spotFiller.ts
@@ -192,7 +192,11 @@ export class SpotFillerBot implements Bot {
 			market.marketIndex
 		);
 
-		// TODO: check oracle validity when ready
+		// Check if oracle is valid
+		if (!this.clearingHouse.oracleIsValid) {
+			// return no nodes to fill given oracle is not valid
+			return nodes;
+		}
 
 		await this.dlobMutex.runExclusive(async () => {
 			const serumSubscriber = this.serumSubscribers.get(market.marketIndex);

--- a/src/bots/spotFiller.ts
+++ b/src/bots/spotFiller.ts
@@ -339,7 +339,7 @@ export class SpotFillerBot implements Bot {
 						delete this.dlob;
 					}
 					this.dlob = new DLOB(
-						this.clearingHouse.getPerpMarketAccounts(), // TODO: new sdk - remove this
+						this.clearingHouse.getPerpMarketAccounts(),
 						this.clearingHouse.getSpotMarketAccounts(),
 						this.clearingHouse.getStateAccount(),
 						this.userMap,

--- a/src/display.ts
+++ b/src/display.ts
@@ -128,7 +128,6 @@ export async function getWallet(): Promise<Wallet> {
 	return new Wallet(keypair);
 }
 
-// TODO: update this with an aggregation of endpoints and check their ping
 const endpoint = process.env.ENDPOINT;
 logger.info(`RPC endpoint: ${endpoint}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,6 @@ export async function getWallet(): Promise<Wallet> {
 	return new Wallet(keypair);
 }
 
-// TODO: update this with an aggregation of endpoints and check their ping
 const endpoint = process.env.ENDPOINT;
 logger.info(`RPC endpoint: ${endpoint}`);
 


### PR DESCRIPTION
- updating some sdk code and comments 
- updating readme 
- determined integrating one of the only functioning perp platforms (since mango) [01](https://01.xyz) did not make sense given they have little to no liquidity and would only make hedging a small amount of sol exposure possible (other markets have next to no liquidity). Potentially can integrate with other spot/lend markets but many like solend are going through similar manipulations/problems that cause lending super high etc. Ideally hedging is integrating across drifts own lending/spot (once more pairs are available) and checks rates across perp platforms (once they are liquid and functional)